### PR TITLE
Gnome 46 Compatibility update

### DIFF
--- a/compact-top-bar@metehan-arslan.github.io/extension.js
+++ b/compact-top-bar@metehan-arslan.github.io/extension.js
@@ -24,8 +24,8 @@ export default class CompactTopBar extends Extension {
         }
 
         this._actorSignalIds.set(global.window_group, [
-            global.window_group.connect('actor-added', this._onWindowActorAdded.bind(this)),
-            global.window_group.connect('actor-removed', this._onWindowActorRemoved.bind(this))
+            global.window_group.connect('child-added', this._onWindowActorAdded.bind(this)),
+            global.window_group.connect('child-removed', this._onWindowActorRemoved.bind(this))
         ]);
 
         this._actorSignalIds.set(global.window_manager, [

--- a/compact-top-bar@metehan-arslan.github.io/metadata.json
+++ b/compact-top-bar@metehan-arslan.github.io/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Adds transparency effects (including notification tray) and slims the top bar for more space. See github page for more screenshots.",
   "name": "Compact Top Bar",
-  "shell-version": ["45"],
+  "shell-version": ["45", "46"],
   "url": "https://github.com/metehan-arslan/gnome-compact-top-bar",
   "uuid": "gnome-compact-top-bar@metehan-arslan.github.io",
   "version": 6


### PR DESCRIPTION
Updated GJS deprecated signal names for Gnome 46 compatibility accoding to https://gjs.guide/extensions/upgrading/gnome-shell-46.html#gjs