### PR TITLE
Ignore fullscreen windows

### DIFF
--- a/compact-top-bar@metehan-arslan.github.io/extension.js
+++ b/compact-top-bar@metehan-arslan.github.io/extension.js
@@ -83,11 +83,13 @@ export default class CompactTopBar extends Extension {
             return metaWindow.is_on_primary_monitor()
                     && metaWindow.showing_on_its_workspace()
                     && !metaWindow.is_hidden()
+                    && !metaWindow.is_fullscreen()
                     && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP;
         } else {
             return !metaWindow.is_on_primary_monitor()
                     && metaWindow.showing_on_its_workspace()
                     && !metaWindow.is_hidden()
+                    && !metaWindow.is_fullscreen()
                     && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP;
         }
             


### PR DESCRIPTION
- Minor compatibility fix for Fullscreen Avoider extension: removes a small delay making the Top bar transparent when it gets moved to secondary display.