### PR TITLE
Update the metadata to support Gnome 47 release

### DIFF
--- a/compact-top-bar@metehan-arslan.github.io/metadata.json
+++ b/compact-top-bar@metehan-arslan.github.io/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Adds transparency effects (including notification tray) and slims the top bar for more space. See github page for more screenshots.",
   "name": "Compact Top Bar",
-  "shell-version": ["46"],
+  "shell-version": ["46","47"],
   "url": "https://github.com/metehan-arslan/gnome-compact-top-bar",
   "uuid": "gnome-compact-top-bar@metehan-arslan.github.io",
   "version": 6


### PR DESCRIPTION
Very simple update to support Gnome 47 - did some local testing and a review of the changelog, this works on 47 fine.

```
{
  "description": "Adds transparency effects (including notification tray) and slims the top bar for more space. See github page for more screenshots.",
  "name": "Compact Top Bar",
  **"shell-version": ["46","47"],**
  "url": "https://github.com/metehan-arslan/gnome-compact-top-bar",
  "uuid": "gnome-compact-top-bar@metehan-arslan.github.io",
  "version": 6
}
```